### PR TITLE
リセットボタンの実装

### DIFF
--- a/develop/index.js
+++ b/develop/index.js
@@ -35,7 +35,14 @@ const onStart = () => {
     }
 };
 //リセット処理
-const onReset = () => { };
+const onReset = () => {
+    //タイマーを停止---①
+    stopTimer();
+    //カウントをリセット---②
+    resetCount();
+    //描画を更新
+    updateView();
+};
 /*==============================
 イベントリスナー
 ==============================*/
@@ -92,4 +99,9 @@ function stopTimer() {
     clearInterval(timerID);
     //計測状態を「停止中」に変更---②
     isRunning = false;
+}
+//カウントをリセット
+function resetCount() {
+    //経過時間を初期化
+    timeCount = 0;
 }

--- a/develop/index.ts
+++ b/develop/index.ts
@@ -41,7 +41,14 @@ const onStart = () => {
 };
 
 //リセット処理
-const onReset = () => {};
+const onReset = () => {
+    //タイマーを停止---①
+    stopTimer();
+    //カウントをリセット---②
+    resetCount();
+    //描画を更新
+    updateView();
+};
 
 
 /*==============================
@@ -107,4 +114,10 @@ function stopTimer() {
     clearInterval(timerID);
     //計測状態を「停止中」に変更---②
     isRunning = false;
+}
+
+//カウントをリセット
+function resetCount() {
+    //経過時間を初期化
+    timeCount = 0;
 }


### PR DESCRIPTION
### やったこと
- リセットボタンをクリックしたときに呼び出される `onReset` 関数（タイマーを停止し、カウントをリセットする）を実装した。

### 学んだこと
- リセットボタンをクリックする直前のカウントは、最後に `updateView` 関数が実行された時点のカウントで、 `timeCount` を0に戻した後は `updateView` 関数を呼び出していないため直前の表示が残ったままになるので、 `onReset` 関数の最後に `updateView` 関数を呼び出す手順を追加すればよい。